### PR TITLE
fix drizzle config

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,11 @@
-const config = {
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
   dialect: "postgresql",
   schema: "./src/db/schema.ts",
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: process.env.DATABASE_URL as string,
   },
   verbose: true,
   strict: true,
-};
-
-export default config;
+});


### PR DESCRIPTION
## Problem Encountered

I was unable to run Drizzle migrations with npx drizzle-kit push because Drizzle could not find the required database connection details. The error message was:

```
Either connection "url" or "host", "database" are required for PostgreSQL database connection
```

## What I Did to Fix It
I verified that the Dockerized Postgres instance was running and accessible.

I checked that my .env file contained a valid DATABASE_URL and that it was being loaded correctly.

I refactored drizzle.config.ts to use the recommended defineConfig helper from the Drizzle Kit documentation.

I updated the dbCredentials property to use url: process.env.DATABASE_URL as string to satisfy Drizzle’s type requirements and ensure the environment variable was properly passed.

## Result
After making these changes, Drizzle Kit was able to connect to the database and successfully apply the schema migrations. 
