### PR TITLE
fix: use number for yearsOfExperience and phoneNumber in Advocate type

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,8 @@ type Advocate = {
   city: string;
   degree: string;
   specialties: string[];
-  yearsOfExperience: string;
-  phoneNumber: string;
+  yearsOfExperience: number;
+  phoneNumber: number;
 };
 
 export default function Home() {
@@ -37,7 +37,7 @@ export default function Home() {
         advocate.city.includes(searchTerm) ||
         advocate.degree.includes(searchTerm) ||
         advocate.specialties.join(",").includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
+        advocate.yearsOfExperience.toString().includes(searchTerm)
       );
     });
     setFilteredAdvocates(filteredAdvocates);


### PR DESCRIPTION
This pull request updates the `Advocate` type and related logic in `src/app/page.tsx` to ensure type safety and correct search behavior:

- Changes `yearsOfExperience` and `phoneNumber` fields in the `Advocate` type from `string` to `number` to match the database schema and seed data.
- Updates the search logic to use `.toString()` on `yearsOfExperience` for string matching.
- Ensures consistency between the frontend type definitions and backend data.

These changes prevent runtime errors and improve maintainability.