### PR TITLE
chore: always export real db instance, throw if DATABASE_URL is missing

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,20 +1,11 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
-const setup = () => {
-  if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
-  }
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is not set");
+}
 
-  // for query purposes
-  const queryClient = postgres(process.env.DATABASE_URL);
-  const db = drizzle(queryClient);
-  return db;
-};
+const client = postgres(process.env.DATABASE_URL);
+const db = drizzle(client);
 
-export default setup();
+export default db;


### PR DESCRIPTION
This pull request updates the `src/db/index.ts` file to always export the real Drizzle database instance. The previous fallback logic that returned a mock object when `DATABASE_URL` was missing has been removed. Now, if `DATABASE_URL` is not set, an error is thrown immediately.

**Summary of changes:**
- Always export a real Drizzle/Postgres database instance.
- Throw a clear error if `DATABASE_URL` is missing, instead of returning a mock.
- Removes unnecessary fallback logic for improved reliability and type safety.

This change ensures that all database operations use a real connection and fail fast if the environment is not properly configured.